### PR TITLE
Fix app grid's fade-in animation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -314,6 +314,11 @@ function enable() {
         this._backgroundGroup.get_children().forEach((background) => {
             background.brightness = 1.0;
             background.opacity = 255;
+            
+            // Give Applications a transparent background so it can fade in
+            if (Main.overview.viewSelector.getActivePage() == ViewSelector.ViewPage.APPS) {
+                background.opacity = 0;
+            }
 
             // VERY IMPORTANT: This somehow removes the initial workspaces
             // darkening. Not sure how, but it does.
@@ -331,6 +336,10 @@ function enable() {
 
     // This can be blank. I dunno why, but it can be ¯\_(ツ)_/¯
     inject(Main.overview, '_unshadeBackgrounds', function () {
+        // Avoid graphical glitches if the background was transparent
+        this._backgroundGroup.get_children().forEach((background) => {
+            background.opacity = 255;
+        })
         return true;
     });
 


### PR DESCRIPTION
This does not actually fix<b></b> https://github.com/pop-os/cosmic/issues/47, but it does fix the appearance of the fade-in animation of the opaque background for the app grid. The exit animation for the app grid is still buggy (see both #47 and #24.)

Before:
https://user-images.githubusercontent.com/7199422/122617505-a25b1400-d049-11eb-8280-0a93c8d3b8ea.mp4

After:
https://user-images.githubusercontent.com/7199422/122617507-a38c4100-d049-11eb-983c-437b064ad647.mp4
