### PR TITLE
fix: Verify `stateObj` is defined

### DIFF
--- a/overview.js
+++ b/overview.js
@@ -3,7 +3,7 @@ const ViewSelector = imports.ui.viewSelector;
 
 function with_pop_shell(callback) {
     let pop_shell = Main.extensionManager.lookup("pop-shell@system76.com");
-    if (pop_shell) {
+    if (pop_shell && pop_shell.stateObj) {
         let ext = pop_shell.stateObj.ext;
         if (ext) {
             return callback(ext);


### PR DESCRIPTION
Should fix https://github.com/pop-os/cosmic/issues/101.

Not sure exactly what is triggering it in that issue, but I can reproduce it by disabling Pop Shell.
