### PR TITLE
fix: Test if stylesheet is `null` in `shell_theme_is_pop()`

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -182,7 +182,11 @@ function gesture(kind) {
 }
 
 function shell_theme_is_pop() {
-    return Main.getThemeStylesheet().get_path().startsWith("/usr/share/themes/Pop");
+    const stylesheet = Main.getThemeStylesheet();
+    if (stylesheet)
+        return stylesheet.get_path().startsWith("/usr/share/themes/Pop");
+    else
+        return true;
 }
 
 function show_overview_backgrounds() {


### PR DESCRIPTION
This seems to normally be `null` with the "User Themes" extension disabled, which caused an error.

For some reason this seems to have broken the workspace switcher when opening "Applications" then switching to "Workspaces."