### PR TITLE
Fix: Date Menu when Dash2Panel is used 

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -39,6 +39,14 @@ const CLOCK_RIGHT = 2;
 
 let indicatorPad = null;
 function clock_alignment(alignment) {
+    
+    // Clock Alignement breaks Date Menu, when other extensions like Dash2Panel are used
+    let dash2Panel = Main.extensionManager.lookup("dash-to-panel@jderose9.github.com");
+    if(dash2Panel && dash2Panel.stateObj){
+        return;
+    }
+ 
+
     const dateMenu = Main.panel.statusArea['dateMenu'];
     const container = dateMenu.container;
     const parent = container.get_parent();

--- a/extension.js
+++ b/extension.js
@@ -39,13 +39,11 @@ const CLOCK_RIGHT = 2;
 
 let indicatorPad = null;
 function clock_alignment(alignment) {
-    
     // Clock Alignement breaks Date Menu, when other extensions like Dash2Panel are used
     let dash2Panel = Main.extensionManager.lookup("dash-to-panel@jderose9.github.com");
-    if(dash2Panel && dash2Panel.stateObj){
+    if(dash2Panel && dash2Panel.state == ExtensionUtils.ExtensionState.ENABLED){
         return;
     }
- 
 
     const dateMenu = Main.panel.statusArea['dateMenu'];
     const container = dateMenu.container;


### PR DESCRIPTION
Fixes #134
This is a very simple fix (I'm not very fluent in Javascript) to the missing clock button when Dash2Panel is used. 
