### PR TITLE
improv: Do not hide `window_group` on Applications screen

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -286,7 +286,6 @@ function enable() {
     Main.panel.addToStatusArea("cosmic_applications", applications_button, 1, "left");
 
     // Hide search and modify background
-    Main.overview._overview._searchEntry.hide();
     // This signal cannot be connected until Main.overview is initialized
     GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
         if (Main.overview._initCalled) {
@@ -294,11 +293,13 @@ function enable() {
                 Main.layoutManager._updateVisibility();
 
                 if (Main.overview.viewSelector.getActivePage() === ViewSelector.ViewPage.WINDOWS) {
-                    Main.overview._overview._searchEntry.hide();
+                    Main.overview._overview._searchEntry.opacity = 0;
+                    Main.overview._overview._searchEntry.reactive = false;
                     Main.overview._overview.remove_style_class_name("cosmic-solid-bg");
                     show_overview_backgrounds();
                 } else {
-                    Main.overview._overview._searchEntry.show();
+                    Main.overview._overview._searchEntry.opacity = 255;
+                    Main.overview._overview._searchEntry.reactive = true;
                     Main.overview._overview.add_style_class_name("cosmic-solid-bg");
                     hide_primary_overview_backgrounds();
                 }

--- a/extension.js
+++ b/extension.js
@@ -291,6 +291,8 @@ function enable() {
     GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
         if (Main.overview._initCalled) {
             search_signal_page_changed = Main.overview.viewSelector.connect('page-changed', () => {
+                Main.layoutManager._updateVisibility();
+
                 if (Main.overview.viewSelector.getActivePage() === ViewSelector.ViewPage.WINDOWS) {
                     Main.overview._overview._searchEntry.hide();
                     Main.overview._overview.remove_style_class_name("cosmic-solid-bg");
@@ -376,6 +378,15 @@ function enable() {
     // This can be blank. I dunno why, but it can be ¯\_(ツ)_/¯
     inject(Main.overview, '_unshadeBackgrounds', function () {
         return true;
+    });
+
+    inject(Main.layoutManager, "_updateVisibility", function () {
+        let windowsVisible = (Main.sessionMode.hasWindows && !this._inOverview) || Main.overview.viewSelector._showAppsButton.checked;
+
+        global.window_group.visible = windowsVisible;
+        global.top_window_group.visible = windowsVisible;
+
+        this._trackedActors.forEach(this._updateActorVisibility.bind(this));
     });
 
     // Block original overlay key handler


### PR DESCRIPTION
This seems to improve the animation opening and closing Applications. It fades cleanly in and out, without the slight visual glitch closing the dock previously.

The only thing is that I'm not sure why Gnome hides `window_group`. It doesn't seem like it should have any visual impact on stock Gnome. Does it eliminate some rendering with a performance impact? Hm...