### PR TITLE
fix: Prevent overlap of dash and workspace switcher without cosmic-dock

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -93,19 +93,13 @@ function clock_alignment(alignment) {
 
 function workspace_picker_direction(controls, left) {
     if (left) {
-        let first = controls._group.get_first_child();
-        if (first != controls._thumbnailsSlider) {
-            controls._thumbnailsSlider.layout.slideDirection = OverviewControls.SlideDirection.LEFT;
-            controls._thumbnailsBox.add_style_class_name('workspace-thumbnails-left');
-            controls._group.set_child_below_sibling(controls._thumbnailsSlider, first)
-        }
+        controls._thumbnailsSlider.layout.slideDirection = OverviewControls.SlideDirection.LEFT;
+        controls._thumbnailsBox.add_style_class_name('workspace-thumbnails-left');
+        controls._group.set_child_below_sibling(controls._thumbnailsSlider, controls.viewSelector);
     } else {
-        let last = controls._group.get_last_child();
-        if (last != controls._thumbnailsSlider) {
-            controls._thumbnailsSlider.layout.slideDirection = OverviewControls.SlideDirection.RIGHT;
-            controls._thumbnailsBox.remove_style_class_name('workspace-thumbnails-left');
-            controls._group.set_child_above_sibling(controls._thumbnailsSlider, last);
-        }
+        controls._thumbnailsSlider.layout.slideDirection = OverviewControls.SlideDirection.RIGHT;
+        controls._thumbnailsBox.remove_style_class_name('workspace-thumbnails-left');
+        controls._group.set_child_above_sibling(controls._thumbnailsSlider, controls.viewSelector);
     }
 
     const handler_id = Main.overview.connect('showing', () => {


### PR DESCRIPTION
With the `cosmic-dock` extension disabled, and the workspace switcher on the left, the dash and workspace switcher overlapped. This fixes that.

![Screenshot from 2021-07-26 10-05-41](https://user-images.githubusercontent.com/2263150/127030491-47949daa-89a4-4c98-9dab-b2a8646514a4.png)
