### PR TITLE
WIP: Add keybindings to workspaces overview

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -385,6 +385,24 @@ function enable() {
 
         let symbol = event.get_key_symbol();
 
+        if (!Main.overview.viewSelector._showAppsButton.checked) {
+            let workspaceManager = global.workspace_manager;
+            let activeWs = workspaceManager.get_active_workspace();
+            let ws;
+            switch (event.get_key_symbol()) {
+            case Clutter.KEY_Up:
+            case Clutter.KEY_k:
+                ws = activeWs.get_neighbor(Meta.MotionDirection.UP);
+                Main.wm.actionMoveWorkspace(ws);
+                return;
+            case Clutter.KEY_Down:
+            case Clutter.KEY_j:
+                ws = activeWs.get_neighbor(Meta.MotionDirection.DOWN);
+                Main.wm.actionMoveWorkspace(ws);
+                return;
+            }
+        }
+
         if (symbol === Clutter.KEY_Escape) {
             if (this._searchActive) this.reset();
             Main.overview.hide();


### PR DESCRIPTION
Implementation of https://github.com/pop-os/cosmic/issues/141.

As implemented, this bindings up/down and k/j to switching between workspaces when the Workspaces view is open. This matches the behavior Gnome has by default with PageUp/PageDown.

I wonder what other bindings could be added here. Not having key presses directed to search opens more possibilities.

Draft PR, because I don't think we want to merge behavioral changes like this mid-release. If we like how it works, we could add a gsetting to enable these bindings, which can be toggled in desktop-widget, and make it default to off but perhaps change that default in 21.10.