### PR TITLE
fix: Make `focusSearch` show the Applications view

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -488,6 +488,11 @@ function enable() {
         });
     }
 
+    inject(Main.overview, 'focusSearch', function () {
+        overview_show(OVERVIEW_APPLICATIONS);
+        this._overview.searchEntry.grab_key_focus();
+    });
+
     inject(Main.layoutManager, "_updateVisibility", function () {
         let windowsVisible = (Main.sessionMode.hasWindows && !this._inOverview) || Main.overview.dash.showAppsButton.checked;
 


### PR DESCRIPTION
Hopefully fixes https://github.com/pop-os/cosmic/issues/193, though I can't quite reproduce it. The behavior seems better with this change though.