### PR TITLE
Fix bug in #183

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRC = extension.js \
       metadata.json \
       overview.js \
       prefs.js \
+      prefs.ui \
       schemas/gschemas.compiled \
       schemas/org.gnome.shell.extensions.pop-cosmic.gschema.xml \
       settings.js \

--- a/extension.js
+++ b/extension.js
@@ -121,7 +121,7 @@ function workspace_picker_direction(controls, left) {
     });
 }
 
-var overlay_key_action = OVERVIEW_LAUNCHER;
+var overlay_key_action = null;
 
 function overlay_key() {
     if (overlay_key_action !== null) {

--- a/extension.js
+++ b/extension.js
@@ -130,16 +130,23 @@ function overlay_key() {
 }
 
 function overlay_key_changed(settings) {
-    if (overview_visible(overlay_key_action)) {
+    const overlay_key_is_disabled = settings.get_boolean("disable-overlay-key");
+    const overlay_key_was_disabled = (overlay_key_action === null);
+
+    if (overview_visible(overlay_key_action) && !overlay_key_was_disabled) {
         overview_hide(overlay_key_action);
     }
-    const overlay_key_is_disabled = settings.get_boolean("disable-overlay-key");
+
     if (overlay_key_is_disabled) {
         overlay_key_action = null;
-        disconnect_overlay_key_handler();
+        if (!overlay_key_was_disabled) {
+            disconnect_overlay_key_handler();
+        }
     } else {
         overlay_key_action = settings.get_enum("overlay-key-action");
-        connect_overlay_key_handler();
+        if (overlay_key_was_disabled) {
+            connect_overlay_key_handler();
+        }
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -137,20 +137,16 @@ function overlay_key_changed(settings) {
         overview_hide(overlay_key_action);
     }
 
-    if (overlay_key_is_disabled) {
-        overlay_key_action = null;
-        if (!overlay_key_was_disabled) {
-            disconnect_overlay_key_handler();
-        }
-    } else {
-        overlay_key_action = settings.get_enum("overlay-key-action");
-        if (overlay_key_was_disabled) {
-            connect_overlay_key_handler();
-        }
+    if (overlay_key_is_disabled && !overlay_key_was_disabled) {
+        disconnect_overlay_key_handler();
+    } else if (!overlay_key_is_disabled && overlay_key_was_disabled) {
+        connect_overlay_key_handler(settings.get_enum("overlay-key-action"));
     }
 }
 
-function connect_overlay_key_handler() {
+function connect_overlay_key_handler(action) {
+    overlay_key_action = action;
+
     // Block original overlay key handler
     original_signal_overlay_key = GObject.signal_handler_find(global.display, { signalId: "overlay-key" });
     if (original_signal_overlay_key !== null) {
@@ -168,6 +164,8 @@ function connect_overlay_key_handler() {
 }
 
 function disconnect_overlay_key_handler() {
+    overlay_key_action = null;
+
     // Disconnect modified overlay key handler
     if (signal_overlay_key !== null) {
         global.display.disconnect(signal_overlay_key);

--- a/extension.js
+++ b/extension.js
@@ -137,10 +137,17 @@ function overlay_key_changed(settings) {
         overview_hide(overlay_key_action);
     }
 
-    if (overlay_key_is_disabled && !overlay_key_was_disabled) {
-        disconnect_overlay_key_handler();
-    } else if (!overlay_key_is_disabled && overlay_key_was_disabled) {
-        connect_overlay_key_handler(settings.get_enum("overlay-key-action"));
+    if (overlay_key_is_disabled) {
+        if (!overlay_key_was_disabled) {
+            disconnect_overlay_key_handler();
+        }
+    } else {
+        const action = settings.get_enum("overlay-key-action");
+        if (overlay_key_was_disabled) {
+            connect_overlay_key_handler(action);
+        } else {
+            overlay_key_action = action;
+        }
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -54,7 +54,7 @@ let indicatorPad = null;
 function clock_alignment(alignment) {
     // Clock Alignement breaks Date Menu, when other extensions like Dash2Panel are used
     let dash2Panel = Main.extensionManager.lookup("dash-to-panel@jderose9.github.com");
-    if(dash2Panel && dash2Panel.state == ExtensionUtils.ExtensionState.ENABLED){
+    if (dash2Panel && dash2Panel.state == ExtensionUtils.ExtensionState.ENABLED) {
         return;
     }
 
@@ -66,7 +66,7 @@ function clock_alignment(alignment) {
     const container = dateMenu.container;
     const parent = container.get_parent();
     if (parent != null) {
-        parent.remove_child (container);
+        parent.remove_child(container);
     }
 
     const banner_width = Main.panel.statusArea.dateMenu._messageList.width;
@@ -315,17 +315,17 @@ function page_changed() {
         }
 
         view.ease({
-           opacity: opacity,
-           duration: Overview.ANIMATION_TIME,
-           mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            opacity: opacity,
+            duration: Overview.ANIMATION_TIME,
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
         });
     });
 }
 
 function page_empty() {
     getWorkspacesDisplay()._workspacesViews.forEach(view => {
-       if (Main.overview.dash.showAppsButton.checked && view._monitorIndex != Main.layoutManager.primaryIndex)
-           view.opacity = 0;
+        if (Main.overview.dash.showAppsButton.checked && view._monitorIndex != Main.layoutManager.primaryIndex)
+            view.opacity = 0;
     });
 }
 
@@ -333,7 +333,7 @@ function monitors_changed() {
     clock_alignment(settings.get_enum("clock-alignment"));
 }
 
-function init(metadata) {}
+function init(metadata) { }
 
 function enable() {
     // Raise first window on alt-tab
@@ -391,13 +391,13 @@ function enable() {
     }
 
     // Hide activities button
-    activities_signal_show = Main.panel.statusArea.activities.connect("show", function() {
+    activities_signal_show = Main.panel.statusArea.activities.connect("show", function () {
         Main.panel.statusArea.activities.hide();
     });
     Main.panel.statusArea.activities.hide();
 
     // Hide app menu
-    appMenu_signal_show = Main.panel.statusArea.appMenu.connect("show", function() {
+    appMenu_signal_show = Main.panel.statusArea.appMenu.connect("show", function () {
         Main.panel.statusArea.appMenu.hide();
     });
     Main.panel.statusArea.appMenu.hide();
@@ -513,7 +513,7 @@ function enable() {
 
                 // VERY IMPORTANT: This somehow removes the initial workspaces
                 // darkening. Not sure how, but it does.
-                if(background.content == undefined) {
+                if (background.content == undefined) {
                     // Shell version 3.36
                     background.vignette = false;
                     background.brightness = 1.0;
@@ -579,7 +579,7 @@ function disable() {
     Main.wm.removeKeybinding('toggle-application-view');
 
     let obj = GNOME_VERSION.startsWith("3.38") ? Main.overview.viewSelector
-                                               : Main.overview._overview._controls;
+        : Main.overview._overview._controls;
     Main.wm.addKeybinding(
         'toggle-application-view',
         new Gio.Settings({ schema_id: SHELL_KEYBINDINGS_SCHEMA }),
@@ -639,9 +639,9 @@ function disable() {
 
     // Remove injections
     let i;
-    for(i in injections) {
-       let injection = injections[i];
-       injection["object"][injection["parameter"]] = injection["value"];
+    for (i in injections) {
+        let injection = injections[i];
+        injection["object"][injection["parameter"]] = injection["value"];
     }
 
     clock_alignment(CLOCK_CENTER);

--- a/prefs.js
+++ b/prefs.js
@@ -20,63 +20,17 @@ function init() {
 }
 
 function buildPrefsWidget() {
-    const label = new Gtk.Label({
-        label: "Configuration for the dock, the top bar, the workspaces overview, and\nother COSMIC components is available in the Settings application.",
-        justify: Gtk.Justification.CENTER,
-    });
+    const ui_file = extension.dir.get_path() + "/prefs.ui";
+    const ui = Gtk.Builder.new_from_file(ui_file);
 
-    const button = new Gtk.Button({
-        label: "Configure in Settings",
-        halign: Gtk.Align.CENTER,
-    });
-    button.connect("clicked", open_panel);
+    const settings_button = ui.get_object("button-settings");
+    settings_button.connect("clicked", open_panel);
 
-    const box = new Gtk.Box({
-        orientation: Gtk.Orientation.VERTICAL,
-        spacing: 18,
-        halign: Gtk.Align.CENTER,
-        valign: Gtk.Align.CENTER,
-    });
-    box.add(label);
-    box.add(button);
-    box.add(new Gtk.Separator({}));
-    box.add(buildNichePrefsWidget());
-
-    box.show_all();
-
-    return box;
-}
-
-function buildNichePrefsWidget() {
-    const box = new Gtk.Box({
-        orientation: Gtk.Orientation.VERTICAL,
-        spacing: 9,
-        halign: Gtk.Align.FILL,
-        valign: Gtk.Align.CENTER,
-    });
-    box.add(new Gtk.Label({
-        label: "<b>Advanced Settings</b>",
-        justify: Gtk.Justification.CENTER,
-        use_markup: true,
-    }));
-
-    const superKeyBox = new Gtk.Box({
-        orientation: Gtk.Orientation.HORIZONTAL,
-        spacing: 9,
-        halign: Gtk.Align.FILL,
-        valign: Gtk.Align.CENTER,
-    });
-    superKeyBox.add(new Gtk.Label({
-        label: "Disable Super key action (reverts to GNOME default)",
-    }));
-    const superKeySwitch = new Gtk.Switch({
-        active: settings.get_boolean("disable-overlay-key"),
-    });
-    superKeySwitch.connect("notify::active", (widget) => {
+    const disable_super_switch = ui.get_object("switch-disable-super");
+    disable_super_switch.set_state(settings.get_boolean("disable-overlay-key"));
+    disable_super_switch.connect("notify::active", (widget) => {
         settings.set_boolean("disable-overlay-key", widget.active);
     });
-    superKeyBox.add(superKeySwitch);
-    box.add(superKeyBox);
 
-    return box;
+    return ui.get_object("main-widget");
 }

--- a/prefs.js
+++ b/prefs.js
@@ -55,7 +55,7 @@ function buildNichePrefsWidget() {
         valign: Gtk.Align.CENTER,
     });
     box.add(new Gtk.Label({
-        label: "<b>Niche Settings</b>",
+        label: "<b>Advanced Settings</b>",
         justify: Gtk.Justification.CENTER,
         use_markup: true,
     }));
@@ -67,7 +67,7 @@ function buildNichePrefsWidget() {
         valign: Gtk.Align.CENTER,
     });
     superKeyBox.add(new Gtk.Label({
-        label: "Disable super key action (reverts to gnome default)",
+        label: "Disable Super key action (reverts to GNOME default)",
     }));
     const superKeySwitch = new Gtk.Switch({
         active: settings.get_boolean("disable-overlay-key"),

--- a/prefs.js
+++ b/prefs.js
@@ -2,6 +2,13 @@ const Gdk = imports.gi.Gdk;
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
 
+const ExtensionUtils = imports.misc.extensionUtils;
+const extension = ExtensionUtils.getCurrentExtension();
+
+var { settings_new_schema } = extension.imports.settings;
+
+let settings = null;
+
 function open_panel() {
     const appinfo = Gio.DesktopAppInfo.new("gnome-background-panel.desktop");
     const launch_ctx = Gdk.Display.get_default().get_app_launch_context();
@@ -9,6 +16,7 @@ function open_panel() {
 }
 
 function init() {
+    settings = settings_new_schema(extension.metadata["settings-schema"]);
 }
 
 function buildPrefsWidget() {
@@ -31,7 +39,44 @@ function buildPrefsWidget() {
     });
     box.add(label);
     box.add(button);
+    box.add(new Gtk.Separator({}));
+    box.add(buildNichePrefsWidget());
+
     box.show_all();
+
+    return box;
+}
+
+function buildNichePrefsWidget() {
+    const box = new Gtk.Box({
+        orientation: Gtk.Orientation.VERTICAL,
+        spacing: 9,
+        halign: Gtk.Align.FILL,
+        valign: Gtk.Align.CENTER,
+    });
+    box.add(new Gtk.Label({
+        label: "<b>Niche Settings</b>",
+        justify: Gtk.Justification.CENTER,
+        use_markup: true,
+    }));
+
+    const superKeyBox = new Gtk.Box({
+        orientation: Gtk.Orientation.HORIZONTAL,
+        spacing: 9,
+        halign: Gtk.Align.FILL,
+        valign: Gtk.Align.CENTER,
+    });
+    superKeyBox.add(new Gtk.Label({
+        label: "Disable super key action (reverts to gnome default)",
+    }));
+    const superKeySwitch = new Gtk.Switch({
+        active: settings.get_boolean("disable-overlay-key"),
+    });
+    superKeySwitch.connect("notify::active", (widget) => {
+        settings.set_boolean("disable-overlay-key", widget.active);
+    });
+    superKeyBox.add(superKeySwitch);
+    box.add(superKeyBox);
 
     return box;
 }

--- a/prefs.js
+++ b/prefs.js
@@ -9,6 +9,8 @@ var { settings_new_schema } = extension.imports.settings;
 
 let settings = null;
 
+const DISABLE_SUPER_SETTINGS_KEY = "disable-overlay-key";
+
 function open_panel() {
     const appinfo = Gio.DesktopAppInfo.new("gnome-background-panel.desktop");
     const launch_ctx = Gdk.Display.get_default().get_app_launch_context();
@@ -27,9 +29,14 @@ function buildPrefsWidget() {
     settings_button.connect("clicked", open_panel);
 
     const disable_super_switch = ui.get_object("switch-disable-super");
-    disable_super_switch.set_state(settings.get_boolean("disable-overlay-key"));
+    disable_super_switch.set_state(settings.get_boolean(DISABLE_SUPER_SETTINGS_KEY));
     disable_super_switch.connect("notify::active", (widget) => {
-        settings.set_boolean("disable-overlay-key", widget.active);
+        settings.set_boolean(DISABLE_SUPER_SETTINGS_KEY, widget.active);
+    });
+    settings.connect("changed", (settings, key) => {
+        if (key === DISABLE_SUPER_SETTINGS_KEY) {
+            disable_super_switch.set_state(settings.get_boolean(key));
+        }
     });
 
     return ui.get_object("main-widget");

--- a/prefs.ui
+++ b/prefs.ui
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkBox" id="main-widget">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-left">72</property>
+    <property name="margin-right">72</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">18</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Configuration for the dock, the top bar, the workspaces overview, and other COSMIC components is available in the Settings application.</property>
+            <property name="justify">center</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button-settings">
+            <property name="label" translatable="yes">Configure in Settings</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="halign">center</property>
+            <property name="valign">center</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="padding">36</property>
+        <property name="position">0</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSeparator">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">18</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="valign">start</property>
+            <property name="label" translatable="yes">Advanced Settings</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">9</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">9</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">Disable Super key override</property>
+                    <property name="wrap">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">&lt;span font_size="smaller" alpha="55%"&gt;Super will open Workspaces unless behavior is specified by other extensions&lt;/span&gt;</property>
+                    <property name="use-markup">True</property>
+                    <property name="wrap">True</property>
+                    <property name="xalign">0</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="switch-disable-super">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="halign">end</property>
+                <property name="valign">start</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="padding">18</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/schemas/org.gnome.shell.extensions.pop-cosmic.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.pop-cosmic.gschema.xml
@@ -16,6 +16,9 @@
           <summary>Overlay key action</summary>
           <description>Controls the action of the overlay key, typically Super</description>
         </key>
+        <key type="b" name="disable-overlay-key">
+            <default>false</default>
+        </key>
         <key type="b" name="show-applications-button">
             <default>true</default>
         </key>


### PR DESCRIPTION
Fix bug in PR #183 as found in #195

The issue was that an enable/disable cycle without restarting the shell was not a no-op. I didn't consider that state (in particular, `overlay_key_action` in this case, which is also used as the flag for whether or not the overlay key is disabled) would remain.

To fix this, I've moved the logic of setting `overlay_key_action` into the `dis/connect_overlay_key_handler` functions, so that state always stays in sync with whether or not the handler is actually connected.

It has fixed the issue in my testing locking/unlocking.