### PR TITLE
i18n(es-ES): Add translation to desktop files

### DIFF
--- a/usr/share/applications/pop-cosmic-applications.desktop
+++ b/usr/share/applications/pop-cosmic-applications.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Show Applications
 Name[pt_BR]=Mostrar Aplicativos
+Name[es_ES]=Mostrar Aplicaciones
 Exec=dbus-send --session --dest=org.gnome.Shell --type=method_call /org/gnome/Shell org.gnome.Shell.Eval string:'let pop_cosmic = Main.extensionManager.lookup("pop-cosmic@system76.com"); if (pop_cosmic) { pop_cosmic.stateObj.overview_toggle(pop_cosmic.stateObj.OVERVIEW_APPLICATIONS); }'
 Icon=pop-cosmic-applications
 Type=Application

--- a/usr/share/applications/pop-cosmic-launcher.desktop
+++ b/usr/share/applications/pop-cosmic-launcher.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Show Launcher
 Name[pt_BR]=Mostrar Lançador
+Name[es_ES]=Mostrar Lanzador
 Exec=dbus-send --session --dest=org.gnome.Shell --type=method_call /org/gnome/Shell org.gnome.Shell.Eval string:'let pop_cosmic = Main.extensionManager.lookup("pop-cosmic@system76.com"); if (pop_cosmic) { pop_cosmic.stateObj.overview_toggle(pop_cosmic.stateObj.OVERVIEW_LAUNCHER); }'
 Icon=pop-cosmic-launcher
 Type=Application

--- a/usr/share/applications/pop-cosmic-workspaces.desktop
+++ b/usr/share/applications/pop-cosmic-workspaces.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Name=Show Workspaces
 Name[pt_BR]=Mostrar Áreas de Trabalho
+Name[es_ES]=Mostrar Áreas de Trabajo
 Exec=dbus-send --session --dest=org.gnome.Shell --type=method_call /org/gnome/Shell org.gnome.Shell.Eval string:'let pop_cosmic = Main.extensionManager.lookup("pop-cosmic@system76.com"); if (pop_cosmic) { pop_cosmic.stateObj.overview_toggle(pop_cosmic.stateObj.OVERVIEW_WORKSPACES); }'
 Icon=pop-cosmic-workspaces
 Type=Application


### PR DESCRIPTION
Adds Spanish (Spain) translation to to desktop files. Attached screens show it working:

![Captura de pantalla de 2021-11-10 10-27-55](https://user-images.githubusercontent.com/168440/141143354-a1d06566-c95d-45af-aee0-076cdf1118a5.png)
![Captura de pantalla de 2021-11-10 10-28-18](https://user-images.githubusercontent.com/168440/141143356-cabbe6cc-42d6-42ef-b142-e139b1a60c41.png)
![lanzador](https://user-images.githubusercontent.com/168440/141143359-e5db2d9e-9b96-4bcc-805f-ad8147c5f57e.png)
