### PR TITLE
Applications Popup Improvements

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -741,6 +741,7 @@ var CosmicSearchResultsView = GObject.registerClass({
             name: 'searchResultsContent',
             vertical: true,
             x_expand: true,
+	    style_class: 'cosmic-applications-search-results',
         });
         this.add_actor(this._content);
         // TODO: scroll
@@ -758,12 +759,15 @@ var CosmicSearchResultsView = GObject.registerClass({
         provider.display = providerDisplay;
         this._providers.push(provider);
 
+        const available_label = new St.Label({ text: "Available to Install", style_class: "cosmic-applications-available" });
+	this._content.add(available_label);
+
         const appInfo = Gio.DesktopAppInfo.new("io.elementary.appcenter.desktop");
         const busName = "io.elementary.appcenter";
         const objectPath = "/io/elementary/appcenter/SearchProvider";
         if (appInfo) {
             const provider = new RemoteSearchProvider2(appInfo, busName, objectPath, true);
-            const providerDisplay = new Search.ListSearchResults(provider, this);
+            const providerDisplay = new Search.GridSearchResults(provider, this);
             this._content.add(providerDisplay)
             provider.display = providerDisplay;
             this._providers.push(provider);

--- a/applications.js
+++ b/applications.js
@@ -1,6 +1,7 @@
 const { Clutter, Gio, GLib, GObject, Pango, Shell, St } = imports.gi;
 const AppDisplay = imports.ui.appDisplay;
 const { BaseIcon } = imports.ui.iconGrid;
+const Dialog = imports.ui.dialog;
 const DND = imports.ui.dnd;
 const { ExtensionState } = imports.misc.extensionUtils;
 const Main = imports.ui.main;
@@ -17,20 +18,16 @@ let dialog = null;
 
 var CosmicFolderEditDialog = GObject.registerClass({
 }, class CosmicFolderEditDialog extends ModalDialog {
-    _init(title, acceptText, hasEntry, onAccept) {
+    _init(title, description, acceptText, hasEntry, onAccept) {
         super._init();
+        this.dialogLayout._dialog.add_style_class_name('cosmic-folder-edit-dialog');
 
-        const box = new St.BoxLayout({ vertical: true });
-        this.contentLayout.add(box);
-
-        if (title !== null) {
-            const label = new St.Label({ text: title });
-            box.add_actor(label);
-        }
+        const contentBox = new Dialog.MessageDialogContent({ title, description });
+        this.contentLayout.add_child(contentBox);
 
         if (hasEntry) {
             this._entry = new St.Entry();
-            box.add_actor(this._entry);
+            contentBox.add_actor(this._entry);
         }
 
         this.addButton({
@@ -700,7 +697,7 @@ var CosmicAppDisplay = GObject.registerClass({
     }
 
     open_create_folder_dialog() {
-        new CosmicFolderEditDialog(null, "Create", true, (dialog) => {
+        new CosmicFolderEditDialog("New Folder", "Folder Name", "Create", true, (dialog) => {
             this.create_folder(dialog.entry.get_text());
         });
     }
@@ -708,7 +705,8 @@ var CosmicAppDisplay = GObject.registerClass({
     open_delete_folder_dialog() {
         const id = this.folder.id;
 
-        new CosmicFolderEditDialog("Delete folder?", "Delete", false, (dialog) => {
+        const desc = "Deleting this folder will move the application icons to Library Home.";
+        new CosmicFolderEditDialog("Delete Folder?", desc, "Delete", false, (dialog) => {
             this.delete_folder(id);
             this.setFolder(null);
         });
@@ -722,7 +720,7 @@ var CosmicAppDisplay = GObject.registerClass({
 
         const name = this._folders[id].name;
 
-        const dialog = new CosmicFolderEditDialog(null, "Rename", true, (dialog) => {
+        const dialog = new CosmicFolderEditDialog("Rename Folder", null, "Rename", true, (dialog) => {
             this.rename_folder(id, dialog.entry.get_text());
         });
         dialog.entry.set_text(name);

--- a/applications.js
+++ b/applications.js
@@ -430,9 +430,10 @@ var CosmicModalDialog = GObject.registerClass({
         // doesn't work properly, since part of the dock is blocked by
         // `modalDialogGroup`, which has the size of the dialog but at the
         // top left.
-        const modalDialogGroup = Main.layoutManager.modalDialogGroup;
-        modalDialogGroup.remove_actor(this);
-        Main.layoutManager.uiGroup.insert_child_below(this, modalDialogGroup);
+        //
+        // Also, place lower in `uiGroup` so popup notifications are over it.
+        Main.layoutManager.modalDialogGroup.remove_actor(this);
+        Main.layoutManager.uiGroup.insert_child_above(this, Main.layoutManager.overviewGroup);
     }
 
     vfunc_allocate(box) {

--- a/applications.js
+++ b/applications.js
@@ -531,6 +531,7 @@ var CosmicAppDisplay = GObject.registerClass({
                 homogeneous: true,
             }),
             x_expand: true,
+            x_align: Clutter.ActorAlign.CENTER,
         });
         this.add_actor(this._folderBox);
 

--- a/applications.js
+++ b/applications.js
@@ -910,9 +910,9 @@ var CosmicAppsDialog = GObject.registerClass({
         this.connect("key-press-event", (_, event) => {
             if (event.get_key_symbol() == Clutter.KEY_Escape)
                 this.hideDialog();
-            else if (this.appDisplay.visible && event.get_key_symbol() == Clutter.KEY_Page_Down)
+            else if (!this.inSearch && event.get_key_symbol() == Clutter.KEY_Page_Down)
                 this.appDisplay.select_next_folder();
-            else if (this.appDisplay.visible && event.get_key_symbol() == Clutter.KEY_Page_Up)
+            else if (!this.inSearch && event.get_key_symbol() == Clutter.KEY_Page_Up)
                 this.appDisplay.select_previous_folder();
         });
 

--- a/applications.js
+++ b/applications.js
@@ -273,6 +273,8 @@ var CosmicAppIcon = GObject.registerClass({
         this.icon.x_expand = true;
         this.icon.y_expand = true;
 
+        this._dot.opacity = 0;
+
         // Vertically center label in available space
         this.icon.label.y_expand = true;
 

--- a/applications.js
+++ b/applications.js
@@ -946,6 +946,9 @@ var CosmicAppsDialog = GObject.registerClass({
         this.open();
         this._header.reset();
         this.appDisplay.reset();
+
+        // Update 'checked' state of Applications button
+        Main.panel.statusArea['cosmic_applications'].update();
     }
 
     hideDialog() {
@@ -955,6 +958,9 @@ var CosmicAppsDialog = GObject.registerClass({
         if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED) {
             cosmicDock.stateObj.dockManager._allDocks.forEach((dock) => dock._onOverviewHiding());
         }
+
+        // Update 'checked' state of Applications button
+        Main.panel.statusArea['cosmic_applications'].update();
     }
 });
 

--- a/applications.js
+++ b/applications.js
@@ -724,6 +724,18 @@ var CosmicAppDisplay = GObject.registerClass({
         });
         dialog.entry.set_text(name);
     }
+
+    select_next_folder() {
+        const next = this.folder.get_next_sibling();
+        if (next instanceof CosmicFolderButton)
+            this.setFolder(next.id);
+    }
+
+    select_previous_folder() {
+        const prev = this.folder.get_previous_sibling();
+        if (prev instanceof CosmicFolderButton)
+            this.setFolder(prev.id);
+    }
 });
 
 // This needs to implement an API similar to SearchResultsView since
@@ -884,8 +896,12 @@ var CosmicAppsDialog = GObject.registerClass({
         this.contentLayout.add(box);
         this.dialogLayout._dialog.add_style_class_name('cosmic-applications-dialog');
         this.connect("key-press-event", (_, event) => {
-            if (event.get_key_symbol() == 65307)
+            if (event.get_key_symbol() == Clutter.KEY_Escape)
                 this.hideDialog();
+            else if (this.appDisplay.visible && event.get_key_symbol() == Clutter.KEY_Page_Down)
+                this.appDisplay.select_next_folder();
+            else if (this.appDisplay.visible && event.get_key_symbol() == Clutter.KEY_Page_Up)
+                this.appDisplay.select_previous_folder();
         });
 
         this.button_press_id = global.stage.connect('button-press-event', () => {

--- a/applications.js
+++ b/applications.js
@@ -29,6 +29,11 @@ var CosmicFolderEditDialog = GObject.registerClass({
         if (hasEntry) {
             this._entry = new St.Entry();
             contentBox.add_actor(this._entry);
+
+            this._entry.clutter_text.connect('activate', () => {
+                onAccept(this);
+                this.close();
+            });
         }
 
         this.addButton({
@@ -43,6 +48,7 @@ var CosmicFolderEditDialog = GObject.registerClass({
                 onAccept(this);
                 this.close();
             },
+            default: true,
         });
 
         this.open();

--- a/applications.js
+++ b/applications.js
@@ -160,7 +160,7 @@ var CosmicFolderButton = GObject.registerClass({
     }
 
     get name() {
-        return this.label.text;
+        return this._name;
     }
 
     _updateApps() {
@@ -196,20 +196,18 @@ var CosmicFolderButton = GObject.registerClass({
     }
 
     _updateName() {
-        let name;
-
         if (this.settings === null) {
-            name = 'Library Home';
+            this._name = 'Library Home';
         } else {
-            name = this.settings.get_string('name');
+            this._name = this.settings.get_string('name');
             if (this.settings.get_boolean('translate')) {
-                const translated = Shell.util_get_translated_folder_name(name);
+                const translated = Shell.util_get_translated_folder_name(this._name);
                 if (translated !== null)
-                    name = translated;
+                    this._name = translated;
             }
         }
 
-        this.label.text = name;
+        this.label.text = this._name || 'Untitled';
         this.notify('name');
     }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -36,3 +36,12 @@
 .cosmic-base-folder-button {
         width: 120px;
 }
+
+.cosmic-applications-available {
+	color: #ffffff;
+	font-weight: bold;
+}
+
+.cosmic-applications-search-results {
+	spacing: 32px;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -45,3 +45,11 @@
 .cosmic-applications-search-results {
 	spacing: 32px;
 }
+
+.cosmic-folder-edit-dialog {
+	min-width: 512px;
+}
+
+.cosmic-folder-edit-dialog .message-dialog-description {
+	text-align: left;
+}


### PR DESCRIPTION
Addressees some of the points in https://github.com/pop-os/cosmic/issues/228.

* Dialogs now have a minimum width, and are formatted with a title and description.
* Empty folder titles are displayed as "Untitled"
  - Would it be good if this is somehow distinct from that actual text? Not that anyone would probably want to label it that.
* Center folder icon box
* Remove dot in app icon, which doesn't really fit here
* Things like notifications now appear over the Applications popup, not under
* PageUp/PageDown to change folder
* Update 'checked' state of Applications button based on whether popup is open 
* Search
  -  There is now a timeout for shop search results, like stock Gnome Shell; seems to help a bit
     * I think the performance should match what it was before; not sure if the code in Pop Shop could be improved too
     * Does not delay local app search
   - Formatted like mockup with "Available to Install" label
   - Spinner indicates shop results are loading