### PR TITLE
fix: Close Applictions on `Main.overview.hide()`

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -451,15 +451,9 @@ function gnome_40_enable() {
 
     applications.enable();
 
-    const appIcon_activate = AppDisplay.AppIcon.prototype.activate;
-    inject(AppDisplay.AppIcon.prototype, 'activate', function(button) {
-        appIcon_activate.call(this, button);
-        applications.hide();
-    });
-
-    const searchResult_activate = Search.SearchResult.prototype.activate;
-    inject(Search.SearchResult.prototype, 'activate', function() {
-        searchResult_activate.call(this);
+    const overview_hide = Main.overview.hide;
+    inject(Main.overview, 'hide', function() {
+        overview_hide.call(this);
         applications.hide();
     });
 }


### PR DESCRIPTION
This seems to work more correctly. It still closes on clicking an app icon or search result, but also on "New Window", "Show Details", etc.

Fixes https://github.com/pop-os/beta/issues/319.