### PR TITLE
More App Library improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ endif
 INSTALLNAME = $(UUID)
 
 SRC = applications.js \
+      dark.css \
       extension.js \
+      light.css \
       metadata.json \
       overview.js \
       prefs.js \

--- a/applications.js
+++ b/applications.js
@@ -12,6 +12,7 @@ const ParentalControlsManager = imports.misc.parentalControlsManager;
 const { RemoteSearchProvider2 } = imports.ui.remoteSearch;
 const Search = imports.ui.search;
 const { getTermsForSearchString } = imports.ui.searchController;
+const Util = imports.misc.util;
 
 // TODO translate
 
@@ -522,7 +523,9 @@ var CosmicAppDisplay = GObject.registerClass({
         let appIcons = [];
         Shell.AppSystem.get_default().get_installed().forEach(appInfo => {
             const app = Shell.AppSystem.get_default().lookup_app(appInfo.get_id());
-            appIcons.push(new CosmicAppIcon(app));
+            const app_icon = new CosmicAppIcon(app);
+            app_icon.connect('key-focus-in', this._keyFocusIn.bind(this));
+            appIcons.push(app_icon);
         });
         appIcons.sort((a, b) => a.app.get_name().localeCompare(b.app.get_name()))
                 .forEach(icon => this._box.add_actor(icon));
@@ -554,6 +557,10 @@ var CosmicAppDisplay = GObject.registerClass({
 
         this._updateHomeApps();
         this.setFolder(null);
+    }
+
+    _keyFocusIn(app_icon) {
+        Util.ensureActorVisibleInScrollView(this._scrollView, app_icon);
     }
 
     _updateHomeApps() {
@@ -617,7 +624,9 @@ var CosmicAppDisplay = GObject.registerClass({
             const app = Shell.AppSystem.get_default().lookup_app(appInfo.get_id());
             for (const icon of this._box.get_children()) {
                 if (icon.app.get_name().localeCompare(app.get_name()) > 0) {
-                    this._box.insert_child_above(new CosmicAppIcon(app), icon);
+                    const app_icon = new CosmicAppIcon(app);
+                    app_icon.connect('key-focus-in', this._keyFocusIn.bind(this));
+                    this._box.insert_child_above(app_icon, icon);
                     break;
                 }
             }

--- a/applications.js
+++ b/applications.js
@@ -337,7 +337,7 @@ var CosmicAppsHeader = GObject.registerClass({
         this.add_actor(this._folderHeader);
 
         this._searchEntry = new St.Entry({
-            style_class: 'search-entry',
+            style_class: 'cosmic-applications-search-entry',
             hint_text: _('Type to search'),
             track_hover: true,
             can_focus: true,

--- a/applications.js
+++ b/applications.js
@@ -279,8 +279,6 @@ var CosmicAppIcon = GObject.registerClass({
         this.icon.x_expand = true;
         this.icon.y_expand = true;
 
-        this._dot.opacity = 0;
-
         // Vertically center label in available space
         this.icon.label.y_expand = true;
 

--- a/applications.js
+++ b/applications.js
@@ -787,6 +787,7 @@ var CosmicSearchResultsView = GObject.registerClass({
 
             this._shop_provider = new RemoteSearchProvider2(appInfo, busName, objectPath, true);
             const providerDisplay = new Search.GridSearchResults(this._shop_provider, this);
+            providerDisplay._resultDisplayBin.x_align = Clutter.ActorAlign.START;
             this._content.add(providerDisplay)
             this._shop_provider.display = providerDisplay;
         }

--- a/dark.css
+++ b/dark.css
@@ -1,0 +1,15 @@
+.cosmic-applications-dialog {
+       background-color: #36322f;
+}
+
+.cosmic-applications-icon {
+       color: #9b9b9b;
+}
+
+.cosmic-applications-folder-title {
+       color: #ffffff;
+}
+
+.cosmic-applications-available {
+       color: #ffffff;
+}

--- a/extension.js
+++ b/extension.js
@@ -451,6 +451,12 @@ function gnome_40_enable() {
 
     applications.enable();
 
+    const overview_show = Main.overview.show;
+    inject(Main.overview, 'show', function() {
+        overview_show.call(this);
+        applications.hide();
+    });
+
     const overview_hide = Main.overview.hide;
     inject(Main.overview, 'hide', function() {
         overview_hide.call(this);

--- a/light.css
+++ b/light.css
@@ -1,0 +1,23 @@
+.cosmic-applications-dialog .overview-icon {
+	color: black;
+}
+
+.app-well-app:focus .overview-icon {
+	background-color: #9b9b9b;
+}
+
+.cosmic-applications-icon {
+	color: black;
+}
+
+.cosmic-applications-folder-title {
+	color: black;
+}
+
+.cosmic-applications-available {
+	color: black;
+}
+
+.cosmic-applications-spinner {
+	color: black;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,17 +1,9 @@
-.cosmic-applications-dialog {
-	background-color: #36322f;
-}
-
 .cosmic-applications-dialog .app-well-app-running-dot {
 	background-color: transparent;
 }
 
 .cosmic-applications-box {
 	spacing: 12px;
-}
-
-.cosmic-applications-icon {
-	color: #9b9b9b;
 }
 
 .cosmic-applications-separator {
@@ -27,7 +19,6 @@
 }
 
 .cosmic-applications-folder-title {
-	color: #ffffff;
 	font-weight: bold;
 	font-size: 1.5em;
 }
@@ -46,7 +37,6 @@
 }
 
 .cosmic-applications-available {
-	color: #ffffff;
 	font-weight: bold;
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2,6 +2,10 @@
 	background-color: #36322f;
 }
 
+.cosmic-applications-dialog .app-well-app-running-dot {
+	background-color: transparent;
+}
+
 .cosmic-applications-box {
 	spacing: 12px;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,6 +32,10 @@
 	font-size: 1.5em;
 }
 
+.cosmic-applications-search-entry {
+	width: 504px;  /* 168 * 3 */
+}
+
 .cosmic-app-icon {
         height: 168px;
         width: 168px;


### PR DESCRIPTION
Address more of the issues in https://github.com/pop-os/cosmic/issues/228.

* Hide dot in search results
* Hide applications when workspace overview is opened
* Left align Available to Install results to line up with header
* Scroll apps when moving key focus
* Adjust search style to match border radius/width of launcher and mockup
* Use different style depending on dark or light theme

There are still a few other things to fix in the App Library, and some of the colors in the light theme could perhaps be improved. But this is closer to what we want in the 21.10 release.