### PR TITLE
fix: work with uninstalled Pop Shop

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -1063,10 +1063,14 @@ var CosmicAppsDialog = GObject.registerClass({
         theme.unload_stylesheet(lightStylesheet);
 
         if (this.is_dark()) {
-            this.resultsView._available_spinner.clear_effects();
+            if (this.resultsView._available_spinner) {
+                this.resultsView._available_spinner.clear_effects();
+            }
             theme.load_stylesheet(darkStylesheet);
         } else {
-            this.resultsView._available_spinner.add_effect(new Shell.InvertLightnessEffect());
+            if (this.resultsView._available_spinner) {
+                this.resultsView._available_spinner.add_effect(new Shell.InvertLightnessEffect());
+            }
             theme.load_stylesheet(lightStylesheet);
         }
 


### PR DESCRIPTION
Hey, Guys. I opened an issue with you https://github.com/pop-os/cosmic/issues/257

The problem was that you did not declare the variable 
`this._available_spinner `
if Pop Shop was not installed. 

I'm not sure that hard linking the code to the Pop Shop is correct, so I corrected this point