### PR TITLE
More App Library Changes

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -409,7 +409,8 @@ var CosmicAppsHeader = GObject.registerClass({
             this._name_binding = this.folder.bind_property('name',
                                                            this._title_label, 'text',
                                                            GObject.BindingFlags.SYNC_CREATE);
-            this.grab_key_focus();
+            if (this.mapped)
+                this.grab_key_focus();
         } else {
             this.reset();
         }
@@ -420,7 +421,8 @@ var CosmicAppsHeader = GObject.registerClass({
 
     reset() {
         this._searchEntry.set_text('');
-        this._searchEntry.grab_key_focus();
+        if (this.mapped)
+            this._searchEntry.grab_key_focus();
     }
 });
 

--- a/applications.js
+++ b/applications.js
@@ -340,7 +340,7 @@ var CosmicAppsHeader = GObject.registerClass({
 
         this._searchEntry = new St.Entry({
             style_class: 'cosmic-applications-search-entry',
-            hint_text: _('Type to search'),
+            hint_text: _('  Type to search'),
             track_hover: true,
             can_focus: true,
             x_align: Clutter.ActorAlign.CENTER,


### PR DESCRIPTION
* Add spacing before "Type to Search" that matches Pop Shell launcher
* Only grab key focus if mapped
   - I think this is the cause of https://github.com/pop-os/beta/issues/333, though I don't seem to be seeing it
* Hide "Available to Install" if DBus service isn't available
  - Though it's still shown but not working if `io.elementary.appcenter` is run without `-s`