### PR TITLE
Remove code for Gnome 3.38 or old Applications view

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -813,16 +813,6 @@ var CosmicSearchResultsView = GObject.registerClass({
             providerDisplay._resultDisplayBin.x_align = Clutter.ActorAlign.START;
             this._content.add(providerDisplay)
             this._shop_provider.display = providerDisplay;
-
-            // Only show section if dbus service is available
-            // Remove this code if it's changed to auto-start
-            const update_available_visibility = () => {
-                const visible = this._shop_provider.proxy.g_name_owner !== null;
-                available_box.visible = visible;
-                providerDisplay.visible = visible;
-            };
-            this._shop_provider.proxy.connect('notify::g-name-owner', update_available_visibility);
-            update_available_visibility();
         }
     }
 
@@ -853,12 +843,8 @@ var CosmicSearchResultsView = GObject.registerClass({
     }
 
     _doSearch(provider) {
-        if (provider == this._shop_provider) {
-            // Remove this code if service changed to auto-start
-            if (this._shop_provider.proxy.g_name_owner === null)
-                return;
+        if (provider == this._shop_provider)
             this._available_spinner.play();
-        }
 
         provider.searchInProgress = true;
 

--- a/overview.js
+++ b/overview.js
@@ -3,8 +3,6 @@ const extension = ExtensionUtils.getCurrentExtension();
 const Main = imports.ui.main;
 const OverviewControls = imports.ui.overviewControls;
 
-const GNOME_VERSION = imports.misc.config.PACKAGE_VERSION;
-
 var applications = extension.imports.applications;
 
 function with_pop_shell(callback) {
@@ -29,13 +27,7 @@ function overview_visible(kind) {
             }
         }
     } else if (kind == OVERVIEW_APPLICATIONS) {
-        if (!GNOME_VERSION.startsWith("3.38")) {
-            return applications.visible();
-        } else if (Main.overview.visibleTarget) {
-            if (Main.overview.dash.showAppsButton.checked) {
-                return true;
-            }
-        }
+        return applications.visible();
     } else if (kind == OVERVIEW_LAUNCHER) {
         if (with_pop_shell((ext) => {
             return ext.window_search.dialog.visible;
@@ -52,21 +44,13 @@ function overview_visible(kind) {
 
 function overview_show(kind) {
     if (kind == OVERVIEW_WORKSPACES) {
-        if (GNOME_VERSION.startsWith("3.38")) {
-            Main.overview.dash.showAppsButton.checked = false;
-            Main.overview.show();
-        } else if (Main.overview.visible) {
+        if (Main.overview.visible) {
             Main.overview.dash.showAppsButton.checked = false;
         } else {
             Main.overview.show(OverviewControls.ControlsState.WINDOW_PICKER);
         }
     } else if (kind == OVERVIEW_APPLICATIONS) {
-        if (GNOME_VERSION.startsWith("3.38")) {
-            Main.overview.dash.showAppsButton.checked = true;
-            Main.overview.show();
-        } else {
-            applications.show();
-        }
+        applications.show();
     } else if (kind == OVERVIEW_LAUNCHER) {
         Main.overview.hide();
         with_pop_shell((ext) => {
@@ -84,7 +68,7 @@ function overview_hide(kind) {
         with_pop_shell((ext) => {
             ext.exit_modes();
         });
-    } else if (kind == OVERVIEW_APPLICATIONS && !GNOME_VERSION.startsWith("3.38")) {
+    } else if (kind == OVERVIEW_APPLICATIONS) {
         applications.hide();
     } else {
         Main.overview.hide();

--- a/topBarButton.js
+++ b/topBarButton.js
@@ -40,14 +40,9 @@ class CosmicTopBarButton extends PanelMenu.Button {
         ];
 
         // This signal cannot be connected until Main.overview is initialized
-        this._pageChangedHandler = null;
         this._notifyCheckedHandler = null;
         this._idleSource = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
             if (Main.overview._initCalled) {
-                this._notifyCheckedHandler = Main.overview.dash.showAppsButton.connect('notify::checked', () => {
-                    this.update();
-                });
-
                 this._idleSource = null;
                 return GLib.SOURCE_REMOVE;
             } else {
@@ -62,8 +57,6 @@ class CosmicTopBarButton extends PanelMenu.Button {
 
             if (this._idleSource !== null) GLib.source_remove(this._idleSource);
             if (this._xdndTimeOut !== null) GLib.source_remove(this._xdndTimeOut);
-            if (this._pageChangedHandler !== null) Main.overview.viewSelector.disconnect(this._pageChangedHandler);
-            if (this._notifyCheckedHandler !== null) Main.overview.dash.showAppsButton.disconnect(this._notifyCheckedHandler);
 
             Gio.Settings.unbind(this, "visible");
         });

--- a/topBarButton.js
+++ b/topBarButton.js
@@ -4,8 +4,6 @@ const extension = ExtensionUtils.getCurrentExtension();
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 
-const GNOME_VERSION = imports.misc.config.PACKAGE_VERSION;
-
 var { OVERVIEW_WORKSPACES, OVERVIEW_APPLICATIONS, OVERVIEW_LAUNCHER } = extension.imports.overview;
 var { overview_visible, overview_show, overview_hide, overview_toggle } = extension.imports.overview;
 
@@ -46,14 +44,9 @@ class CosmicTopBarButton extends PanelMenu.Button {
         this._notifyCheckedHandler = null;
         this._idleSource = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
             if (Main.overview._initCalled) {
-                if (GNOME_VERSION.startsWith("3.38"))
-                    this._pageChangedHandler = Main.overview.viewSelector.connect('page-changed', () => {
-                        this.update();
-                    });
-                else
-                    this._notifyCheckedHandler = Main.overview.dash.showAppsButton.connect('notify::checked', () => {
-                        this.update();
-                    })
+                this._notifyCheckedHandler = Main.overview.dash.showAppsButton.connect('notify::checked', () => {
+                    this.update();
+                });
 
                 this._idleSource = null;
                 return GLib.SOURCE_REMOVE;


### PR DESCRIPTION
This fixes the `TypeError: bgManager.backgroundActor is null` errors on the Gnome Shell log by removing the relevant code.

Otherwise it seems to basically work the same, but having less unnecessary code should generally be good for performance and stability.