### PR TITLE
fix: scale applications library for smaller resolutions

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -448,15 +448,18 @@ var CosmicModalDialog = GObject.registerClass({
         Main.layoutManager.uiGroup.insert_child_above(this, Main.layoutManager.overviewGroup);
     }
 
-    vfunc_allocate(box) {
+    monitor() {
         let index;
         if (this._monitorConstraint.primary)
             index = Main.layoutManager.primaryIndex;
         else
             index = Math.min(this._monitorConstraint.index, Main.layoutManager.monitors.length - 1);
 
-        const monitor = Main.layoutManager.monitors[index];
+        return Main.layoutManager.monitors[index];
+    }
 
+    vfunc_allocate(box) {
+        const monitor = this.monitor();
         const width = Math.min(box.x2 - box.x1, monitor.width);
         const height = Math.min(box.y2 - box.y1, monitor.height);
 
@@ -677,6 +680,10 @@ var CosmicAppDisplay = GObject.registerClass({
 
         if (this._folderId !== undefined)
             this.setFolder(this.folder.id);
+    }
+
+    resize(height, width) {
+        this._scrollView.set_style(`height: ${height}px;width: ${width}px;`);
     }
 
     reset() {
@@ -1138,6 +1145,13 @@ var CosmicAppsDialog = GObject.registerClass({
     showDialog() {
         this.open();
         this._header.reset();
+
+        // Resize Scroll View in App Display based on monitor dimensions
+        const monitor = this.monitor();
+        const height = Math.floor(monitor.height*.5 / 168) * 168;
+        const width = Math.ceil(monitor.width*.6 / 168) * 168;
+        this.appDisplay.resize(height, width);
+
         this.appDisplay.reset();
 
         // Update 'checked' state of Applications button


### PR DESCRIPTION
This scales the applications library to a maximum of 75% of the width
and height.  The constants 1262 and 704 come from the current code
and serve to ensure the behavior for 1080p screens remain the same.

Fixes #264 

Screenshot at 1280x720:

![Screenshot from 2021-12-15 17-19-37](https://user-images.githubusercontent.com/3976244/146274388-a21dcba9-8a3f-464d-a63f-9246a68134e8.png)

Screenshot of 1920x1080:

![Screenshot from 2021-12-15 17-20-03](https://user-images.githubusercontent.com/3976244/146274390-3526226a-ffd3-48bd-98f8-87dea86565a1.png)
