### PR TITLE
disable dark/light stylesheet injection for custom shell themes

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -1064,7 +1064,9 @@ var CosmicAppsDialog = GObject.registerClass({
         const theme = theme_context.get_theme();
         if (!theme)
             return;
-
+        if (!this.is_pop_theme()) 
+            // if using custom theme don't inject styles
+            return;
         let darkStylesheet = extension.dir.get_child("dark.css");
         let lightStylesheet = extension.dir.get_child("light.css");
 
@@ -1093,6 +1095,12 @@ var CosmicAppsDialog = GObject.registerClass({
         const theme = this.theme().toLowerCase();
         return DARK.some(dark => theme.includes(dark));
     }
+    is_pop_theme() {
+        // check if user is using pop/pop-dark default theme
+        const POP = ["pop"];
+        const theme = this.theme().toLowerCase();
+        return POP.some(pop => theme.includes(pop));
+    }
 
     theme() {
         if (this._userThemeSettings)
@@ -1102,14 +1110,16 @@ var CosmicAppsDialog = GObject.registerClass({
 
     _onDestroy() {
         global.stage.disconnect(this.button_press_id);
-
-        let darkStylesheet = extension.dir.get_child("dark.css");
-        let lightStylesheet = extension.dir.get_child("light.css");
-
-        const theme = St.ThemeContext.get_for_stage(global.stage).get_theme();
-        if (theme) {
-            theme.unload_stylesheet(darkStylesheet);
-            theme.unload_stylesheet(lightStylesheet);
+        if (this.is_pop_theme()) {
+            // reload injected stylesheets if using default pop theme
+            let darkStylesheet = extension.dir.get_child("dark.css");
+            let lightStylesheet = extension.dir.get_child("light.css");
+            
+            const theme = St.ThemeContext.get_for_stage(global.stage).get_theme();
+            if (theme) {
+                theme.unload_stylesheet(darkStylesheet);
+                theme.unload_stylesheet(lightStylesheet);
+            }
         }
     }
 


### PR DESCRIPTION
- disable forced stylesheet injection if user is using custom theme to avoid overwriting custom theme css
- specifically for `.cosmic-applications-dialog` background color/text color
- add is_pop_theme() to check if user is using a pop theme
- fixes #276
does this interfere with any other themes dependent on styles injected by `is_dark()`

I tested it on my local machine it appears to work.
Intended functionality:
- if user is using a custom theme prevent cosmic from injecting pop dark styling(text color/background color)
