### PR TITLE
Make app grid's maximum size 7 by 3

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -1149,9 +1149,15 @@ var CosmicAppsDialog = GObject.registerClass({
         // Resize Scroll View in App Display based on monitor dimensions
         const monitor = this.monitor();
         const monitorScale = 1/St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        const height = Math.floor(monitorScale*168) * 3;
-        const width = Math.ceil(monitorScale*168 ) * 7;
-
+        
+        // The grid should never be taller than 3 icons or wider than 7 icons.
+        // If there's not enough room for all of the icons, shrink a little
+        // so it doesn't bump against the edge of the display or go under the panel & dock.
+        const height = Math.min(Math.floor(monitorScale * 168) * 3,
+                                Math.floor(monitorScale * monitor.height * .70 / 168) * 168);
+        const width = Math.min(Math.ceil(monitorScale * 168) * 7,
+                               Math.floor(monitorScale * monitor.width * .90 / 168) * 168);
+        
         this.appDisplay.resize(height, width);
         this.appDisplay.reset();
 

--- a/applications.js
+++ b/applications.js
@@ -1153,9 +1153,9 @@ var CosmicAppsDialog = GObject.registerClass({
         // The grid should never be taller than 3 icons or wider than 7 icons.
         // If there's not enough room for all of the icons, shrink a little
         // so it doesn't bump against the edge of the display or go under the panel & dock.
-        const height = Math.min(Math.floor(monitorScale * 168) * 3,
+        const height = Math.min(168 * 3,
                                 Math.floor(monitorScale * monitor.height * .70 / 168) * 168);
-        const width = Math.min(Math.ceil(monitorScale * 168) * 7,
+        const width = Math.min(168 * 7,
                                Math.floor(monitorScale * monitor.width * .90 / 168) * 168);
         
         this.appDisplay.resize(height, width);

--- a/applications.js
+++ b/applications.js
@@ -1149,8 +1149,8 @@ var CosmicAppsDialog = GObject.registerClass({
         // Resize Scroll View in App Display based on monitor dimensions
         const monitor = this.monitor();
         const monitorScale = 1/St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        const height = Math.floor(monitorScale*monitor.height*.5 / 168) * 168;
-        const width = Math.ceil(monitorScale*monitor.width*.6 / 168) * 168;
+        const height = Math.floor(monitorScale*168) * 3;
+        const width = Math.ceil(monitorScale*168 ) * 7;
 
         this.appDisplay.resize(height, width);
         this.appDisplay.reset();

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -13,9 +13,8 @@
 .cosmic-app-display {
 }
 
+/* Width & height of scroll view are set dynamically to handle scaling. */
 .cosmic-app-scroll-view {
-	height: 504px;  /* 168 * 3 */
-	width: 1176px; /* 168 * 7 */
 }
 
 .cosmic-applications-folder-title {


### PR DESCRIPTION
Fixes #305.

This calculates the app grid's width & height by multiplying the actual size of the icons (168px * scale) by the number of icons we want to display. (Previously, the grid was calculated as a proportion of the display's size, which resulted in inconsistent numbers of icons being displayed on differently-sized/shaped displays.)

I removed pointless CSS settings for the width & height since they weren't being used anyway, since the dynamic calculation already took precedence. I left the class there since there were already some empty classes in the file, and added a note about the dynamic calculation to assist future troubleshooting.

Needs testing on HiDPI & ultrawide displays.