### PR TITLE
fix(apps): add box-shadows to apps dialog

### DIFF
--- a/dark.css
+++ b/dark.css
@@ -1,5 +1,6 @@
 .cosmic-applications-dialog {
        background-color: #36322f;
+       box-shadow: 0 2px 4px 2px rgba(0,0,0,0.1);
 }
 
 .cosmic-applications-icon {

--- a/light.css
+++ b/light.css
@@ -1,3 +1,7 @@
+.cosmic-applications-dialog {
+	box-shadow: 0 2px 4px 2px rgba(0,0,0,0.1);
+}
+
 .cosmic-applications-dialog .overview-icon {
 	color: black;
 }


### PR DESCRIPTION
Greatly aids visibility, especially in the light theme. Needed since the borders are no longer darker than the main window.