### PR TITLE
Fix app library failing to show after screen lock

### DIFF
--- a/dbus_service.js
+++ b/dbus_service.js
@@ -25,7 +25,11 @@ var Service = class {
         this.dbus = Gio.DBusExportedObject.wrapJSObject(IFACE, this);
 
         const onBusAcquired = (conn) => {
-            this.dbus.export(conn, '/com/System76/Cosmic');
+            try {
+                this.dbus.export(conn, '/com/System76/Cosmic')
+            } catch (why) {
+                global.log(`onBusAcquired export failed: ${why}`)
+            }
         };
 
         function onNameAcquired() { }

--- a/extension.js
+++ b/extension.js
@@ -380,6 +380,7 @@ function enable() {
 function disable() {
     // Disable dbus service
     if (service !== null) {
+        service.dbus.unexport()
         service.destroy();
         service = null;
     }


### PR DESCRIPTION
## Instructions to replicate

1. Repeatedly click the "Show Applications" item in the dock multiple times in quick succession
2. Lock the screen with Super + Esc and immediately unlock it
3. Repeat step 1 to see that the app library no longer opens

## Fix

There's an exception that happens in the journald logs for gnome-shell when this happens stating that the DBus service has already been exported. This will unexport the dbus service on extension disable (which happens on a lock screen) to allow it to re-export successfully.