### PR TITLE
fix: Exception when cosmicDock.stateObj.dockManager may be undefined

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -1184,7 +1184,7 @@ var CosmicAppsDialog = GObject.registerClass({
         // Resize Scroll View in App Display based on monitor dimensions
         const monitor = this.monitor();
         const monitorScale = 1/St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        
+
         // The grid should never be taller than 3 icons or wider than 7 icons.
         // If there's not enough room for all of the icons, shrink a little
         // so it doesn't bump against the edge of the display or go under the panel & dock.
@@ -1192,7 +1192,7 @@ var CosmicAppsDialog = GObject.registerClass({
                                 Math.floor(monitorScale * monitor.height * .70 / 168) * 168);
         const width = Math.min(168 * 7,
                                Math.floor(monitorScale * monitor.width * .90 / 168) * 168);
-        
+
         this.appDisplay.resize(height, width);
         this.appDisplay.reset();
 
@@ -1205,7 +1205,12 @@ var CosmicAppsDialog = GObject.registerClass({
 
         const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
         if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED) {
-            cosmicDock.stateObj.dockManager._allDocks.forEach((dock) => dock._onOverviewHiding());
+            const dockManager = cosmicDock.stateObj.dockManager
+            if (dockManager) {
+                dockManager._allDocks.forEach((dock) => dock._onOverviewHiding())
+            } else {
+                log(`cosmic-dock@system76.com was found enabled, but it does not contain a dockManager field`)
+            }
         }
 
         // Update 'checked' state of Applications button

--- a/applications.js
+++ b/applications.js
@@ -1204,7 +1204,7 @@ var CosmicAppsDialog = GObject.registerClass({
         this.close();
 
         const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
-        if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED) {
+        if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED && cosmicDock.stateObj) {
             const dockManager = cosmicDock.stateObj.dockManager
             if (dockManager) {
                 dockManager._allDocks.forEach((dock) => dock._onOverviewHiding())


### PR DESCRIPTION
Issue was reported here https://chat.pop-os.org/pop-os/pl/ttud6b16rt8qxrsz9w16xf38rc

There's a possibility that the `dockManager` field in the cosmic dock extension may be undefined. We should check if the field exists to prevent an exception from breaking things in cosmic.