### PR TITLE
fix (app grid): Adjust vertical padding to improve 1366x768 display

### DIFF
--- a/applications.js
+++ b/applications.js
@@ -1189,7 +1189,7 @@ var CosmicAppsDialog = GObject.registerClass({
         // If there's not enough room for all of the icons, shrink a little
         // so it doesn't bump against the edge of the display or go under the panel & dock.
         const height = Math.min(168 * 3,
-                                Math.floor(monitorScale * monitor.height * .70 / 168) * 168);
+                                Math.floor(monitorScale * monitor.height * .65 / 168) * 168);
         const width = Math.min(168 * 7,
                                Math.floor(monitorScale * monitor.width * .90 / 168) * 168);
 


### PR DESCRIPTION
Reducing the value in this calculation (finding the maximum size that the app launcher should be) forces it to go down to 2 rows tall for 1366x768 displays, which fixes #314.

I checked that this doesn't affect the grid on a 1920x1080 display (it's still 3 rows tall.) We may want to check a couple more resolutions to ensure this doesn't result in an app grid that's too small.